### PR TITLE
Enable modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ SUDS is a **S**imple **U**DP **D**ata **S**tore.  Basically, you send it properl
 
 SUDS is currently in 0.1 version.  It's meant to be minimal, not complex, and intentionally not secure.  (So please don't tell me to put all kinds of security stuff in.)  
 
-## Requirements
-SUDS has the following requirements:
-
-- https://github.com/mattn/go-sqlite3
 
 ## Using SUDS
 This is pretty darn simple
 
+To install via `go get`:
+
     go get github.com/uberlinuxguy/suds
-    go build github.com/uberlinuxguy/suds
+
+Otherwise, you can clone and build manually:
+    
+    git clone https://github.com/uberlinuxguy/suds.git
+    cd suds
+    go install
     
 This will build suds into your $GOPATH/bin directory.  You can run it from there, but where you run it, SUDS will create a `suds.db` file.  You should always make sure you run SUDS from the same directory to maintain state. Perhaps some day I will build in a preferences to set the db path, name, and some other stuff, but hey, this is 0.1 man!
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/uberlinuxguy/suds
+
+go 1.13
+
+require github.com/mattn/go-sqlite3 v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.13.0 h1:LnJI81JidiW9r7pS/hXe6cFeO5EXNq7KbfvoJLRI69c=
+github.com/mattn/go-sqlite3 v1.13.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=


### PR DESCRIPTION
Adds a simple go.mod and minor README updates

Basically, this allows development outside of `$GOPATH` (you can git clone anywhere), and pins the dependencies to specific versions for reproducible builds.   A nice side effect is that you don't need to manually `go get` sqlite3, it'll implicitly be fetched as part of the build process, if not present* already

* By 'present', I mean having been downloaded as a module by `go` before, as part of the implicit build process.  Note:  When in modules mode (i.e. in your source directory, but not in `$GOPATH`), if you do a `go get on a dependency`, it'll explicitly download that module, and place that module in your `go.mod` file as a requirement. 